### PR TITLE
Weighted random track sets, allow mixed glob timings, and fix LastLoadedSoundtrack

### DIFF
--- a/IconDisplayWaitForInit.cs
+++ b/IconDisplayWaitForInit.cs
@@ -29,7 +29,6 @@ namespace TNH_BGLoader
 				bgmpanel.icondisplay = rawimagecomp;
 				rawimagecomp.texture = BankAPI.GetBankIcon(BankAPI.CurrentBankLocation);
 				bgmpanel.SetIcon();
-				bgmpanel.SetText();
 				Destroy(this);
 			}
 			catch

--- a/IconDisplayWaitForInit.cs
+++ b/IconDisplayWaitForInit.cs
@@ -28,6 +28,8 @@ namespace TNH_BGLoader
 				gameObject.transform.localScale = new Vector3(0.15f, 0.15f, 0.15f);
 				bgmpanel.icondisplay = rawimagecomp;
 				rawimagecomp.texture = BankAPI.GetBankIcon(BankAPI.CurrentBankLocation);
+				bgmpanel.SetIcon();
+				bgmpanel.SetText();
 				Destroy(this);
 			}
 			catch

--- a/Patcher_FistVR.cs
+++ b/Patcher_FistVR.cs
@@ -120,14 +120,12 @@ namespace TNHBGLoader
 					if (Path.GetFileNameWithoutExtension(BankAPI.LoadedBankLocations[i]) == PluginMain.LastLoadedBank.Value) {
 						BankAPI.SwapBank(i);
 						bgmpanel.SetIcon();
-						bgmpanel.SetText();
 						break;
 					}
 			
 			if (PluginMain.IsSoundtrack.Value) {
 				SoundtrackAPI.EnableSoundtrackFromGUID(PluginMain.LastLoadedSoundtrack.Value);
 				bgmpanel.SetIcon();
-				bgmpanel.SetText();
 			}
 			//set last loaded announcer
 			AnnouncerAPI.CurrentAnnouncerIndex = AnnouncerAPI.GetAnnouncerIndexFromGUID(PluginMain.LastLoadedAnnouncer.Value);

--- a/Patcher_FistVR.cs
+++ b/Patcher_FistVR.cs
@@ -117,10 +117,18 @@ namespace TNHBGLoader
 			//get the bank last loaded and set banknum to it; if it doesnt exist it just defaults to 0
 			if(!PluginMain.IsSoundtrack.Value)
 				for (int i = 0; i < BankAPI.LoadedBankLocations.Count; i++)
-					if (Path.GetFileNameWithoutExtension(BankAPI.LoadedBankLocations[i]) == PluginMain.LastLoadedBank.Value) { BankAPI.SwapBank(i); break; }
+					if (Path.GetFileNameWithoutExtension(BankAPI.LoadedBankLocations[i]) == PluginMain.LastLoadedBank.Value) {
+						BankAPI.SwapBank(i);
+						bgmpanel.SetIcon();
+						bgmpanel.SetText();
+						break;
+					}
 			
-			//if (PluginMain.IsSoundtrack.Value)
-			//	SoundtrackAPI.EnableSoundtrackFromGUID(PluginMain.LastLoadedSoundtrack.Value);
+			if (PluginMain.IsSoundtrack.Value) {
+				SoundtrackAPI.EnableSoundtrackFromGUID(PluginMain.LastLoadedSoundtrack.Value);
+				bgmpanel.SetIcon();
+				bgmpanel.SetText();
+			}
 			//set last loaded announcer
 			AnnouncerAPI.CurrentAnnouncerIndex = AnnouncerAPI.GetAnnouncerIndexFromGUID(PluginMain.LastLoadedAnnouncer.Value);
 			//set last loaded SosigVLS

--- a/PluginMain.cs
+++ b/PluginMain.cs
@@ -51,7 +51,7 @@ namespace TNHBGLoader
 		public static ConfigEntry<string> LastLoadedAnnouncer;
 		public static ConfigEntry<string> LastLoadedSosigVLS;
 		public static ConfigEntry<bool>   EnableDebugLogging;
-		//public static ConfigEntry<string> LastLoadedSoundtrack;
+		public static ConfigEntry<string> LastLoadedSoundtrack;
 		public static ConfigEntry<bool>   IsSoundtrack;
 
 		public static ConfigEntry<bool> LoadSoundtracksOnStartup;
@@ -113,7 +113,7 @@ namespace TNHBGLoader
 			LastLoadedBank = Config.Bind("no touchy", "Saved Bank", "MX_TAH", "Not meant to be changed manually. This autosaves your last bank used, so you don't have to reset it every time you launch H3.");
 			LastLoadedAnnouncer = Config.Bind("no touchy", "Saved Announcer", "h3vr.default", "Not meant to be changed manually. This autosaves your last announcer used, so you don't have to reset it every time you launch H3.");
 			LastLoadedSosigVLS = Config.Bind("no touchy", "Saved Sosig VLS", "h3vr.default", "Not meant to be changed manually. This autosaves your last sosig set used, so you don't have to reset it every time you launch H3.");
-			//LastLoadedSoundtrack = Config.Bind("no touchy", "Saved Soundtrack", "", "Not meant to be changed manually. This autosaves your last sosig set used, so you don't have to reset it every time you launch H3.");
+			LastLoadedSoundtrack = Config.Bind("no touchy", "Saved Soundtrack", "", "Not meant to be changed manually. This autosaves your last sosig set used, so you don't have to reset it every time you launch H3.");
 			IsSoundtrack = Config.Bind("no touchy", "Saved Is Soundtrack", false, "Not meant to be changed manually. This autosaves your last sosig set used, so you don't have to reset it every time you launch H3.");
 			LoadSoundtracksOnStartup = Config.Bind("no touchy", "Load Soundtracks On Startup", false, "Debug. Loads ALL soundtracks on H3 start, not the current soundtrack when loading TnH. Enable only to catch soundtrack loading bugs on start.");
 		}

--- a/Soundtrack/SoundtrackManifest.cs
+++ b/Soundtrack/SoundtrackManifest.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 
 namespace TNHBGLoader.Soundtrack {
 	
-	public struct Track {
+	public class Track {
 		public AudioClip Clip;
 		public string    Situation;
 		public string[]  Metadata; //sip (Skip In Place), dnf (Do Not Fade), loop, etc
@@ -11,12 +11,13 @@ namespace TNHBGLoader.Soundtrack {
 		public string    Type;
 	}
 
-	public struct TrackSet {
+	public class TrackSet {
 		public List<Track>  Tracks;
 		public string   Situation;
 		public string[] Metadata;
 		public string   Name;
 		public string   Type;
+		public int      RandomWeight;
 	}
 	
 	public class SoundtrackManifest

--- a/Soundtrack/TnHSoundtrackInterface.cs
+++ b/Soundtrack/TnHSoundtrackInterface.cs
@@ -84,7 +84,7 @@ namespace TNHBGLoader.Soundtrack {
 			
 			if(isInstitutionMode && s == "TAH2 Area") {
 
-				TrackSet set = TakeMusic.HasValue ? TakeMusic.Value : HoldMusic;
+				TrackSet set = TakeMusic ?? HoldMusic;
 
 				if (set.Metadata.Contains("nsbr") ||
 				    // If it contains no region metadata, we can assume this is a fallback
@@ -132,8 +132,8 @@ namespace TNHBGLoader.Soundtrack {
 						Track[] alerts = new Track[0];
 						if(HoldMusic.Tracks != null)
 							alerts = HoldMusic.Tracks.Where(x => x.Type == "alert").ToArray();
-						if(!alerts.Any() && TakeMusic.HasValue)
-							alerts = TakeMusic.Value.Tracks.Where(x => x.Type == "alert").ToArray();
+						if(!alerts.Any() && TakeMusic != null)
+							alerts = TakeMusic.Tracks.Where(x => x.Type == "alert").ToArray();
 						if (alerts.Any()) { // there are alerts in the soundtrack
 							storedTakeTrack = CurrentTrack;
 							storedTakeTrackPlayhead = Instance.GetCurrentAudioSource.time;
@@ -154,19 +154,19 @@ namespace TNHBGLoader.Soundtrack {
 						else {
 							float time = 0;
 							// If its restart, force it to go and play takeintro/take
-							if (storedTakeTrack.HasValue && !CurrentTrack.Metadata.Contains("restart")) {
+							if (storedTakeTrack != null && !CurrentTrack.Metadata.Contains("restart")) {
 								float alertPlayhead = Instance.GetCurrentAudioSource.time;
 								time = storedTakeTrackPlayhead + alertPlayhead;
 								// If return, return to where it was
 								if (CurrentTrack.Metadata.Contains("return"))
 									time = storedTakeTrackPlayhead;
-								Instance.SwitchSong(storedTakeTrack.Value, time);
+								Instance.SwitchSong(storedTakeTrack, time);
 							}
 							else {
 								// Get takes
 								TrackSet set;
-								if (TakeMusic.HasValue)
-									set = TakeMusic.Value;
+								if (TakeMusic != null)
+									set = TakeMusic;
 								else
 									set = HoldMusic;
 								
@@ -250,7 +250,7 @@ namespace TNHBGLoader.Soundtrack {
 				QueueTake(HoldMusic);
 			else { //Otherwise, get a take theme.
 				TakeMusic = SoundtrackAPI.GetSet("take", Level);
-				QueueTake(TakeMusic.Value);
+				QueueTake(TakeMusic);
 			}
 
 			currentlyInAlert = false;
@@ -391,7 +391,7 @@ namespace TNHBGLoader.Soundtrack {
 			GM.TNH_Manager.FMODController.MasterBus.setMute(true);
 			//Set hold music.
 			
-			PluginMain.DebugLog.LogInfo($"IsMix: {SoundtrackAPI.IsMix.ToString()}, CurSoundtrack: {SoundtrackAPI.Soundtracks[SoundtrackAPI.SelectedSoundtrackIndex].Guid}, IsSOundtrack: {PluginMain.IsSoundtrack.Value}");
+			PluginMain.DebugLog.LogInfo($"IsMix: {SoundtrackAPI.IsMix.ToString()}, CurSoundtrack: {SoundtrackAPI.Soundtracks[SoundtrackAPI.SelectedSoundtrackIndex].Guid}, IsSoundtrack: {PluginMain.IsSoundtrack.Value}");
 			
 			// Initialize holdmusic
 			PluginMain.DebugLog.LogInfo($"Level: {Level}");
@@ -404,7 +404,7 @@ namespace TNHBGLoader.Soundtrack {
 					QueueTake(HoldMusic);
 				else { //Otherwise, get a take theme.
 					TakeMusic = SoundtrackAPI.GetSet("take", Level);
-					QueueTake(TakeMusic.Value);
+					QueueTake(TakeMusic);
 				}
 			}
 			else {

--- a/TNH-BGLoader.csproj
+++ b/TNH-BGLoader.csproj
@@ -23,10 +23,4 @@
       <None Remove="panel.png" />
       <EmbeddedResource Include="panel.png" />
     </ItemGroup>
-    <ItemGroup>
-
-      <Reference Include="MP3Sharp">
-        <HintPath>lib\MP3Sharp.dll</HintPath>
-      </Reference>
-    </ItemGroup>
 </Project>

--- a/TNHPanel.cs
+++ b/TNHPanel.cs
@@ -295,7 +295,6 @@ namespace TNHBGLoader
 			UpdateMusicList(null, null); //always use null as an arg, kids
 			UpdateVolume(null, null);
 			SetIcon();
-			SetText();
 		}
 		
 		//Updates and changes the BGMs shown
@@ -503,7 +502,6 @@ namespace TNHBGLoader
 						break;
 				}
 				SetIcon();
-				SetText();
 			}
 		}
 		public void PlaySnippet(AudioClip snip)
@@ -530,6 +528,11 @@ namespace TNHBGLoader
 		
 		public void SetIcon()
 		{
+			if (!PluginMain.IsSoundtrack.Value)
+				_bankText.Text.text = "Selected:\n" + GetCurrentSelectedItemName() + "\n(BANK MOD: NO INSTITUTION SUPPORT)"; //set new bank
+			else
+				_bankText.Text.text = "Selected:\n" + GetCurrentSelectedItemName(); //set new bank
+			
 			if (icondisplay == null) return;
 			Debug.Log($"IsMix: {SoundtrackAPI.IsMix.ToString()}, CurBank: {GetCurrentSelectedItemName()}, CurSoundtrack: {SoundtrackAPI.Soundtracks[SoundtrackAPI.SelectedSoundtrackIndex].Guid}");
 			switch (TNHPstate)
@@ -549,14 +552,6 @@ namespace TNHBGLoader
 					icondisplay.texture = SosigVLSAPI.GetSosigVLSIcon(SosigVLSAPI.CurrentSosigVlsOfVlsSet(_selectedVLSSet));
 					break;
 			}
-		}
-		
-		public void SetText()
-		{
-			if (!PluginMain.IsSoundtrack.Value)
-				_bankText.Text.text = "Selected:\n" + GetCurrentSelectedItemName() + "\n(BANK MOD: NO INSTITUTION SUPPORT)"; //set new bank
-			else
-				_bankText.Text.text = "Selected:\n" + GetCurrentSelectedItemName(); //set new bank
 		}
 	}
 }

--- a/TNHPanel.cs
+++ b/TNHPanel.cs
@@ -295,6 +295,7 @@ namespace TNHBGLoader
 			UpdateMusicList(null, null); //always use null as an arg, kids
 			UpdateVolume(null, null);
 			SetIcon();
+			SetText();
 		}
 		
 		//Updates and changes the BGMs shown
@@ -467,6 +468,7 @@ namespace TNHBGLoader
 						if(BGMs[index].IsBank && BGMs[index].BankGuid == "Select Random")
 							index = UnityEngine.Random.Range(0, BGMs.Count);
 						PluginMain.DebugLog.LogInfo($"Setting song to index {index}, {BGMs[index].Name}");
+						BankAPI.NukeSongSnippets(); // Stop any FMOD snippets
 						if (BGMs[index].IsBank) {
 							// Handle Random option
 							BankAPI.SwapBank(index);
@@ -481,6 +483,7 @@ namespace TNHBGLoader
 						}
 						else {
 							PluginMain.IsSoundtrack.Value = true;
+							PluginMain.LastLoadedSoundtrack.Value = BGMs[index].SoundtrackGuid;
 							SoundtrackAPI.EnableSoundtrackFromGUID(BGMs[index].SoundtrackGuid);
 							GameObject go = new GameObject();
 							go.AddComponent(typeof(PlaySoundtrackSnippet));
@@ -500,11 +503,7 @@ namespace TNHBGLoader
 						break;
 				}
 				SetIcon();
-				
-				if(!PluginMain.IsSoundtrack.Value)
-					_bankText.Text.text = "Selected:\n" + GetCurrentSelectedItemName() + "\n(BANK MOD: NO INSTITUTION SUPPORT)"; //set new bank
-				else
-					_bankText.Text.text = "Selected:\n" + GetCurrentSelectedItemName(); //set new bank
+				SetText();
 			}
 		}
 		public void PlaySnippet(AudioClip snip)
@@ -529,7 +528,7 @@ namespace TNHBGLoader
 			SM.PlayGenericSound(audioEvent, GM.CurrentPlayerBody.transform.position);
 		}
 		
-		private void SetIcon()
+		public void SetIcon()
 		{
 			if (icondisplay == null) return;
 			Debug.Log($"IsMix: {SoundtrackAPI.IsMix.ToString()}, CurBank: {GetCurrentSelectedItemName()}, CurSoundtrack: {SoundtrackAPI.Soundtracks[SoundtrackAPI.SelectedSoundtrackIndex].Guid}");
@@ -550,6 +549,14 @@ namespace TNHBGLoader
 					icondisplay.texture = SosigVLSAPI.GetSosigVLSIcon(SosigVLSAPI.CurrentSosigVlsOfVlsSet(_selectedVLSSet));
 					break;
 			}
+		}
+		
+		public void SetText()
+		{
+			if (!PluginMain.IsSoundtrack.Value)
+				_bankText.Text.text = "Selected:\n" + GetCurrentSelectedItemName() + "\n(BANK MOD: NO INSTITUTION SUPPORT)"; //set new bank
+			else
+				_bankText.Text.text = "Selected:\n" + GetCurrentSelectedItemName(); //set new bank
 		}
 	}
 }


### PR DESCRIPTION
1. Changed Track and TrackSet to classes so that we can pass them by reference easily
2. GetWeightedRandomSet chooses a random TrackSet, but is less likely to choose a recently used set
3. Allow comma-separated mixing of glob timings, e.g. 0-2,4,ge6
4. Fix LastLoadedSoundtrack
5. Set the icon and text at startup
